### PR TITLE
feat: Add a RedstoneToV3Oracle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 [submodule "lib/v4-periphery"]
 	path = lib/v4-periphery
 	url = https://github.com/Uniswap/v4-periphery.git
+[submodule "lib/redstone-oracles-monorepo"]
+	path = lib/redstone-oracles-monorepo
+	url = https://github.com/redstone-finance/redstone-oracles-monorepo

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,7 @@ remappings = [
     "solady/=lib/solady/",
     "v4-periphery=lib/v4-periphery",
     "v4-core-for-periphery=lib/v4-periphery/lib/v4-core",
+    "@redstone-finance/=lib/redstone-oracles-monorepo/packages/on-chain-relayer/contracts",
 ]
 evm_version = "cancun"
 

--- a/src/RedstoneToV3Oracle.sol
+++ b/src/RedstoneToV3Oracle.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import { IRedstoneAdapter } from "@redstone-finance/core/IRedstoneAdapter.sol";
+import {IRedstoneAdapter} from "@redstone-finance/core/IRedstoneAdapter.sol";
 import {TickMath} from "v3-core/libraries/TickMath.sol";
 import {FixedPointMathLib} from "solady/src/utils/FixedPointMathLib.sol";
 

--- a/src/RedstoneToV3Oracle.sol
+++ b/src/RedstoneToV3Oracle.sol
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { IRedstoneAdapter } from "@redstone-finance/core/IRedstoneAdapter.sol";
+import {TickMath} from "v3-core/libraries/TickMath.sol";
+import {FixedPointMathLib} from "solady/src/utils/FixedPointMathLib.sol";
+
+/// @title RedstoneToV3Oracle
+/// @notice Contract that provides a Uniswap V3-compatible oracle interface on Redstone-sourced price data.
+contract RedstoneToV3Oracle {
+    /// @notice The Redstone contract this adapter interacts with.
+    IRedstoneAdapter public immutable redstoneAdapter;
+
+    /// @notice The Redstone price feed ID for the desired price feed to source
+    bytes32 public immutable priceFeedId;
+
+    /// @notice In the target market this oracle is supposed to imitate, token1.decimals - token0.decimals
+    ///         (or, if invertTokenOrder, token0.decimals - token1.decimals)
+    int8 public immutable decimalDifferenceFromToken0ToToken1;
+
+    /// @notice Whether to invert the token0/token1 ordering (negate the tick)
+    bool public immutable invertTokenOrder;
+
+    /// @notice The number of decimals that Redstone returns for this price feed (typically 8)
+    uint8 public immutable redstoneDecimals;
+
+    /// @notice Initializes the adapter with the Redstone price feed ID.
+    /// @param _redstoneAdapter The Redstone contract to read price data from
+    /// @param _priceFeedId The ID, such as bytes32("ETH") for ETH<>USD, for the desired price feed to source
+    /// @param _decimalDifferenceFromToken0ToToken1 In the target market, token1.decimals - token0.decimals
+    /// @param _invertTokenOrder Whether to invert the token0/token1 ordering
+    /// @param _redstoneDecimals The number of decimals that Redstone returns for this price feed (typically 8)
+    constructor(
+        IRedstoneAdapter _redstoneAdapter,
+        bytes32 _priceFeedId,
+        int8 _decimalDifferenceFromToken0ToToken1,
+        bool _invertTokenOrder,
+        uint8 _redstoneDecimals
+    ) {
+        redstoneAdapter = _redstoneAdapter;
+        priceFeedId = _priceFeedId;
+        decimalDifferenceFromToken0ToToken1 = _decimalDifferenceFromToken0ToToken1;
+        invertTokenOrder = _invertTokenOrder;
+        redstoneDecimals = _redstoneDecimals;
+    }
+
+    /// @notice Emulates the behavior of the exposed zeroth slot of a Uniswap V3 pool.
+    /// @return sqrtPriceX96 A tick-snapped sqrt price of the oracle, as a sqrt(currency1/currency0) Q64.96 value
+    /// @return tick The current tick of the oracle
+    /// @return observationIndex The index of the last oracle observation that was written
+    /// @return observationCardinality The current maximum number of observations stored in the oracle
+    /// @return observationCardinalityNext The next maximum number of observations that can be stored in the oracle
+    /// @return feeProtocol The protocol fee for this pool (not used in V4, always 0)
+    /// @return unlocked Whether the pool is currently unlocked (always true for V4)
+    function slot0()
+        external
+        view
+        returns (
+            uint160 sqrtPriceX96,
+            int24 tick,
+            uint16 observationIndex,
+            uint16 observationCardinality,
+            uint16 observationCardinalityNext,
+            uint8 feeProtocol,
+            bool unlocked
+        )
+    {
+        unchecked {
+            tick = getRedstonePriceAsTick();
+            // NOTE: that this is tick-snapped and less precise - the opposite of typical
+            // slot0 responses, where `tick` loses some of `sqrtPrice`'s precision
+            sqrtPriceX96 = TickMath.getSqrtRatioAtTick(tick);
+
+            // Always return the max index
+            observationIndex = 65534;
+            // Always return the length of the observations array, so that callers always roll over
+            observationCardinality = 65535;
+            // This value shouldn't be used by callers given the above, but: return 65535, which matches
+            // what Uniswap pools return when all the observations are filled
+            observationCardinalityNext = 65535;
+
+            // not used in v4, so always 0
+            feeProtocol = 0;
+            // always true in v4
+            unlocked = true;
+        }
+    }
+
+    /// @notice Returns data about a specific observation index.
+    /// @param index The element of the observations array to fetch
+    /// @return blockTimestamp The timestamp of the observation
+    /// @return tickCumulative The tick multiplied by seconds elapsed for the life of the pool as of the observation timestamp.
+    /// @return secondsPerLiquidityCumulativeX128 The seconds per in range liquidity for the life of the pool (always 0 in V4)
+    /// @return initialized Whether the observation has been initialized and the values are safe to use
+    function observations(uint256 index)
+        external
+        view
+        returns (
+            uint32 blockTimestamp,
+            int56 tickCumulative,
+            uint160 secondsPerLiquidityCumulativeX128,
+            bool initialized
+        )
+    {
+        unchecked {
+            // Use a blockTimestamp close to now, but unique per-observation
+            // Index 0 was 65534 seconds ago, and the max index was now
+            blockTimestamp = uint32(block.timestamp - 65534 + index);
+            tickCumulative = int56(getRedstonePriceAsTick()) * int56(int32(blockTimestamp));
+
+            // Always 0 in v4
+            secondsPerLiquidityCumulativeX128 = 0;
+            // These values are always safe to use - they're just stubbed based on the pyth price
+            initialized = true;
+        }
+    }
+
+    /// @notice Returns the cumulative tick and liquidity as of each timestamp `secondsAgo` from the current block timestamp.
+    /// @param secondsAgos From how long ago each cumulative tick and liquidity value should be returned
+    /// @return tickCumulatives Cumulative tick values as of each `secondsAgos` from the current block timestamp
+    /// @return secondsPerLiquidityCumulativeX128s Cumulative seconds per liquidity-in-range value (always empty in V4)
+    function observe(uint32[] calldata secondsAgos)
+        external
+        view
+        returns (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s)
+    {
+        unchecked {
+            tickCumulatives = new int56[](secondsAgos.length);
+
+            int24 currentTick = getRedstonePriceAsTick();
+
+            for (uint256 i = 0; i < secondsAgos.length; i++) {
+                // Use the same current tick for all observations
+                // The cumulative = tick * timestamp at that point in time
+                // This ensures TWAP calculations will always result in the current tick
+                tickCumulatives[i] = int56(currentTick) * int56(int256(block.timestamp - secondsAgos[i]));
+            }
+
+            return (tickCumulatives, new uint160[](secondsAgos.length));
+        }
+    }
+
+    /// @notice Get the current price from Redstone with adjustable variation.
+    /// @return The current price from Redstone, converted to a tick
+    function getRedstonePriceAsTick() internal view returns (int24) {
+        // TODO: Here we could check price is not stale, kind of like this:
+        /*
+        uint256 receivedTimestamp = extractTimestampsAndAssertAllAreEqual();
+        if (blockTimestamp - receivedTimestamp > maxAge) {
+          revert InvalidTimestamp(blockTimestamp - receivedTimestamp, maxAge);
+        }
+        and then proceed with the getOracleNumericValueFromTxMsg
+        */
+
+        uint256 price = redstoneAdapter.getValueForDataFeed(priceFeedId);
+
+        // Revert if price is zero - we don't handle zero prices
+        if (price == 0) {
+            revert("Invalid price: zero price from Redstone");
+        }
+
+        // Convert to signed for calculations (should not overflow into negatives - would take a raw price > 2^255)
+        int64 signedPrice = int64(int256(price));
+
+        // Calculate the effective exponent:
+        // We need to account for both Redstone's decimals and the token decimal difference
+        int32 effectiveExponent = -int32(uint32(redstoneDecimals)) + decimalDifferenceFromToken0ToToken1;
+
+        return redstonePriceToTick(signedPrice, effectiveExponent);
+    }
+
+    /// @notice Convert Redstone price directly to tick
+    /// @param price Raw Redstone price (cannot be negative or zero)
+    /// @param decimals Decimal adjustment to get raw-unit price
+    /// @return tick The corresponding Uniswap V3 tick
+    function redstonePriceToTick(int64 price, int32 decimals) internal view returns (int24) {
+        unchecked {
+            // Redstone prices are returned with a fixed number of decimals (typically 8)
+            // We need to scale to get the actual price and account for token decimal differences
+            // Convert to Q128.128 format: (price * 2^128) / 10^(-effectiveExponent)
+            uint256 priceX128 = decimals < 0
+                ? (uint256(uint64(price)) << 128) / uint256(10 ** uint32(-decimals))
+                : (uint256(uint64(price)) << 128) * uint256(10 ** uint32(decimals));
+
+            // Precision of 13 keeps the err <= 0.846169235035 tick - e.g., we're within 1 tick
+            int256 tick = log_1p0001(priceX128, 13);
+
+            // Invert the tick if needed (equivalent to taking reciprocal of price)
+            if (invertTokenOrder) {
+                tick = -tick;
+            }
+
+            return int24(tick);
+        }
+    }
+
+    /// @notice Approximates the absolute value of log base `1.0001` for a number in (0, 2**128) (`argX128/2^128`) with `precision` bits of precision.
+    /// @param argX128 The Q128.128 fixed-point number in the range (0, 2**128) to calculate the log of
+    /// @param precision The bits of precision with which to compute the result, max 63 (`err <≈ 2^-precision * log₂(1.0001)⁻¹`)
+    /// @return The absolute value of log with base `1.0001` for `argX128/2^128`
+    function log_1p0001(uint256 argX128, uint256 precision) internal pure returns (int256) {
+        unchecked {
+            // =[log₂(x)] =MSB(x)
+            int256 log2_res = int256(FixedPointMathLib.log2(argX128));
+            // Normalize argX128 to [1, 2)
+            // x_normal = x / 2^[log₂(x)]
+            // = 1.a₁a₂a₃... = 2^(0.b₁b₂b₃...)
+            // log₂(x_normal) = log₂(x / 2^⌊log₂(x)⌋)
+            // log₂(x_normal) = log₂(x) - log₂(2^⌊log₂(x)⌋)
+            // log₂(x_normal) = log₂(x) - ⌊log₂(x)⌋
+            // log₂(x) = log₂(x_normal) + ⌊log₂(x)⌋
+            if (log2_res >= 128) argX128 = argX128 >> (uint256(log2_res) - 127);
+            else argX128 <<= (127 - uint256(log2_res));
+
+            // =[log₂(x)] * 2^64
+            log2_res = (log2_res - 128) << 64;
+
+            // log₂(x_normal) = 0.b₁b₂b₃...
+            // x_normal = (1.a₁a₂a₃...) = 2^(0.b₁b₂b₃...)
+            // x_normal² = (1.a₁a₂a₃...)² = (2^(0.b₁b₂b₃...))²
+            // = 2^(0.b₁b₂b₃... * 2)
+            // = 2^(b₁ + 0.b₂b₃...)
+            // if bᵢ = 1, renormalize x_normal² to [1, 2):
+            // 2^(b₁ + 0.b₂b₃...) / 2^b₁ = 2^((b₁ - 1).b₂b₃...)
+            // = 2^(0.b₂b₃...)
+            // error = [0, 2⁻ⁿ)
+            uint256 iterBound = 63 - precision;
+            for (uint256 i = 63; i > iterBound; i--) {
+                argX128 = (argX128 ** 2) >> 127;
+                uint256 bit = argX128 >> 128;
+                log2_res = log2_res | int256(bit << i);
+                argX128 >>= bit;
+            }
+
+            // log₁.₀₀₀₁(x) = log₂(x) / log₂(1.0001)
+            // 2^64 / log₂(1.0001) ≈ 127869479499815993737216
+            return (log2_res * 127869479499815993737216) / 2 ** 128;
+        }
+    }
+
+    /// @notice This method is typically used to increase the maximum number of price observations, but we just no-op.
+    /// @dev PanopticFactory relies on this method, so we wanted to expose it, even if it does nothing.
+    /// @param observationCardinalityNext The desired minimum number of observations for the oracle to store
+    function increaseObservationCardinalityNext(uint16 observationCardinalityNext) external {}
+}

--- a/test/RedstoneToV3Oracle.t.sol
+++ b/test/RedstoneToV3Oracle.t.sol
@@ -34,12 +34,12 @@ contract RedstoneToV3OracleTest is Test {
         uint256 forkId = vm.createFork(vm.rpcUrl("unichain"));
         vm.selectFork(forkId);
         wstethOracle = new RedstoneToV3Oracle(
-           redstoneAdapter,
-           wstethEthPriceFeedId,
-           0,    // both wstETH and ETH have 18 decimals, so difference is 0
-           true, // need to invertTokenOrder - ETH is token0 and wstETH is token1 on Uniswap, so the tick is wstETH per ETH; the redstone price is ETH per wstETH
-           8     // redstoneDecimals
-       );
+            redstoneAdapter,
+            wstethEthPriceFeedId,
+            0, // both wstETH and ETH have 18 decimals, so difference is 0
+            true, // need to invertTokenOrder - ETH is token0 and wstETH is token1 on Uniswap, so the tick is wstETH per ETH; the redstone price is ETH per wstETH
+            8 // redstoneDecimals
+        );
     }
 
     function testSlot0ReturnsValidPrice() public {
@@ -57,7 +57,6 @@ contract RedstoneToV3OracleTest is Test {
 
         console.log("Oracle tick: ", oracleTick);
         console.log("V4 Pool tick: ", poolTick);
-
 
         // Convert ticks to comparable prices
         uint256 oraclePrice = convertRawWstethWeiPerEthWeiTickToPrice(oracleTick);

--- a/test/RedstoneToV3Oracle.t.sol
+++ b/test/RedstoneToV3Oracle.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.19;
 
 import "forge-std/Test.sol";
-
 import "../src/RedstoneToV3Oracle.sol";
 import "@redstone-finance/core/IRedstoneAdapter.sol";
 import {TickMath} from "v3-core/libraries/TickMath.sol";
@@ -12,11 +11,9 @@ import {PoolId} from "v4-core-for-periphery/src/types/PoolId.sol";
 
 contract RedstoneToV3OracleTest is Test {
     RedstoneToV3Oracle ethOracle;
-    RedstoneToV3Oracle tonOracle;
     RedstoneToV3Oracle wstethOracle;
 
     bytes32 ethUsdPriceFeedId = bytes32("ETH");
-    bytes32 tonUsdPriceFeedId = bytes32("TON");
     bytes32 wstethEthPriceFeedId = bytes32("wstETH/ETH");
 
     IRedstoneAdapter redstoneAdapter = IRedstoneAdapter(
@@ -28,8 +25,6 @@ contract RedstoneToV3OracleTest is Test {
     // From: https://docs.uniswap.org/contracts/v4/deployments#unichain-130
     IStateView constant stateView = IStateView(0x86e8631A016F9068C3f085fAF484Ee3F5fDee8f2);
 
-    // And also - this contract is upgradeable - under what circumstances might it get upgraded? Our contracts are non-upgradeable so we won't be able to handle any changes in function signature
-
     function setUp() public {
         uint256 forkId = vm.createFork(vm.rpcUrl("unichain"));
         vm.selectFork(forkId);
@@ -40,12 +35,214 @@ contract RedstoneToV3OracleTest is Test {
             true, // need to invertTokenOrder - ETH is token0 and wstETH is token1 on Uniswap, so the tick is wstETH per ETH; the redstone price is ETH per wstETH
             8 // redstoneDecimals
         );
+
+        // Create additional oracles for comprehensive testing
+        ethOracle = new RedstoneToV3Oracle(
+            redstoneAdapter,
+            ethUsdPriceFeedId,
+            -12, // ETH has 18 decimals, USDC has 6, so difference is -12
+            false, // no inversion needed - ETH is token0, USDC is token1, and redstone gives USDC per ETH
+            8 // redstoneDecimals
+        );
     }
 
     function testSlot0ReturnsValidPrice() public {
-        // Test that slot0 does not revert
-        (, int24 tick,,,,,) = wstethOracle.slot0();
+        (
+            uint160 sqrtPriceX96,
+            int24 tick,
+            uint16 obsIdx,
+            uint16 obsCard,
+            uint16 obsCardNext,
+            uint8 feeProtocol,
+            bool unlocked
+        ) = wstethOracle.slot0();
+
+        // Basic sanity checks
+        assertTrue(tick < 0, "wstETH/ETH tick should be < 0, as it takes <1 wstETH to get an ETH");
+        assertEq(feeProtocol, 0, "feeProtocol always 0");
+        assertTrue(unlocked, "unlocked always true");
+        assertEq(obsCard, 65535, "observationCardinality should be max uint16");
+        assertEq(obsCardNext, 65535, "observationCardinalityNext should be max uint16");
+
+        // Verify tick and sqrtPrice are consistent
+        uint160 sqrtPriceFromTick = TickMath.getSqrtRatioAtTick(tick);
+        assertEq(sqrtPriceX96, sqrtPriceFromTick, "tick-snapped sqrtPrice from oracle not equal to sqrtPriceFromTick");
+
         console.log("wstETH Oracle tick: ", tick);
+    }
+
+    function testSlot0ReturnsValidPriceForETH() public {
+        (
+            uint160 sqrtPriceX96,
+            int24 tick,
+            uint16 obsIdx,
+            uint16 obsCard,
+            uint16 obsCardNext,
+            uint8 feeProtocol,
+            bool unlocked
+        ) = ethOracle.slot0();
+
+        // Basic sanity checks for ETH/USD
+        assertLt(int256(tick), 0, "ETH/USD tick should be < 0, unless ETH broke $10^12");
+        assertEq(feeProtocol, 0, "feeProtocol always 0");
+        assertTrue(unlocked, "unlocked always true");
+        assertEq(obsCard, 65535, "observationCardinality should be max uint16");
+        assertEq(obsCardNext, 65535, "observationCardinalityNext should be max uint16");
+
+        // Verify tick and sqrtPrice are consistent
+        uint160 sqrtPriceFromTick = TickMath.getSqrtRatioAtTick(tick);
+        assertEq(sqrtPriceX96, sqrtPriceFromTick, "tick-snapped sqrtPrice from oracle not equal to sqrtPriceFromTick");
+
+        console.log("ETH Oracle tick: ", tick);
+    }
+
+    function testObservationsReturnsValidData() public {
+        for (uint256 i = 0; i < 10; i++) {
+            (uint32 blockTimestamp, int56 tickCumulative, uint160 secondsPerLiquidityX128, bool initialized) =
+                wstethOracle.observations(i);
+
+            // Basic checks
+            assertTrue(initialized, "All observations should be initialized");
+            assertEq(secondsPerLiquidityX128, 0, "secondsPerLiquidity always 0 in V4");
+            assertLe(blockTimestamp, block.timestamp, "blockTimestamp shouldn't be in future");
+            assertEq(
+                blockTimestamp, uint32(block.timestamp - 65534 + i), "blockTimestamp should be now - 65534 + index"
+            );
+        }
+    }
+
+    function testObservationsConsistency() public {
+        // Get two consecutive observations
+        (uint32 ts0, int56 cumulative0,,) = wstethOracle.observations(0);
+        (uint32 ts1, int56 cumulative1,,) = wstethOracle.observations(1);
+
+        // Calculate the tick from cumulative difference
+        int24 derivedTick = int24((cumulative1 - cumulative0) / int56(uint56(ts1 - ts0)));
+
+        // Should match current tick from slot0
+        (, int24 currentTick,,,,,) = wstethOracle.slot0();
+        assertEq(derivedTick, currentTick, "Derived tick from observations should match slot0 tick");
+    }
+
+    function testObserveReturnsValidData() public {
+        uint32[] memory secondsAgos = new uint32[](5);
+        secondsAgos[0] = 0; // now
+        secondsAgos[1] = 60; // 1 minute ago
+        secondsAgos[2] = 300; // 5 minutes ago
+        secondsAgos[3] = 600; // 10 minutes ago
+        secondsAgos[4] = 1800; // 30 minutes ago
+
+        (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = wstethOracle.observe(secondsAgos);
+
+        assertEq(tickCumulatives.length, secondsAgos.length, "Should return same length arrays");
+        assertEq(liquidityCumulatives.length, secondsAgos.length, "Should return same length arrays");
+
+        // All liquidity cumulatives should be 0
+        for (uint256 i = 0; i < liquidityCumulatives.length; i++) {
+            assertEq(liquidityCumulatives[i], 0, "liquidityCumulatives always 0");
+        }
+
+        // Tick cumulatives should be increasing in absolute value (older timestamps = smaller factor to multiply tick by)
+        for (uint256 i = 0; i < tickCumulatives.length - 1; i++) {
+            assertGt(
+                abs(tickCumulatives[i]),
+                abs(tickCumulatives[i + 1]),
+                "Newer observations should have larger absolute-value cumulatives"
+            );
+        }
+    }
+
+    function abs(int56 num) internal pure returns (uint56) {
+        if (num < 0) return uint56(-num);
+        return uint56(num);
+    }
+
+    function testObserveTWAPCalculation() public {
+        uint32[] memory secondsAgos = new uint32[](2);
+        // TODO: Fuzz this - all possible combinations of secondsAgos should still result in TWAP equaling current price.
+        secondsAgos[0] = 0; // now
+        secondsAgos[1] = 600; // 10 minutes ago
+
+        (int56[] memory tickCumulatives,) = wstethOracle.observe(secondsAgos);
+
+        // Calculate TWAP manually
+        int24 twap = int24((tickCumulatives[0] - tickCumulatives[1]) / int56(600));
+
+        // Should equal current tick since we use same tick for all observations
+        (, int24 currentTick,,,,,) = wstethOracle.slot0();
+        assertEq(twap, currentTick, "TWAP should equal current tick");
+    }
+
+    function testFuzzObserveTWAPCalculation(uint32 secondsAgo1, uint32 secondsAgo2) public {
+        // Ensure reasonable bounds and ordering
+        vm.assume(secondsAgo1 <= 86400); // max 1 day
+        vm.assume(secondsAgo2 <= 86400);
+        vm.assume(secondsAgo1 != secondsAgo2); // must be different
+
+        // Ensure proper ordering (secondsAgo2 > secondsAgo1)
+        if (secondsAgo1 > secondsAgo2) {
+            (secondsAgo1, secondsAgo2) = (secondsAgo2, secondsAgo1);
+        }
+
+        uint32[] memory secondsAgos = new uint32[](2);
+        secondsAgos[0] = secondsAgo1;
+        secondsAgos[1] = secondsAgo2;
+
+        (int56[] memory tickCumulatives,) = wstethOracle.observe(secondsAgos);
+
+        // Calculate TWAP manually
+        uint32 timeDiff = secondsAgo2 - secondsAgo1;
+        int24 twap = int24((tickCumulatives[0] - tickCumulatives[1]) / int56(uint56(timeDiff)));
+
+        // Should equal current tick since we use same tick for all observations
+        (, int24 currentTick,,,,,) = wstethOracle.slot0();
+        assertEq(twap, currentTick, "TWAP should equal current tick for any time period");
+    }
+
+    // TODO: Also fuzz test different length arrays (e.g. anywhere from 1 to max array length secondsAgos)
+
+    function testObserveEmptyArray() public {
+        uint32[] memory emptyArray = new uint32[](0);
+        (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = wstethOracle.observe(emptyArray);
+
+        assertEq(tickCumulatives.length, 0, "Should return empty array");
+        assertEq(liquidityCumulatives.length, 0, "Should return empty array");
+    }
+
+    function testObserveLargeArray() public {
+        uint32[] memory largeArray = new uint32[](100);
+        for (uint256 i = 0; i < largeArray.length; i++) {
+            largeArray[i] = uint32(i * 60); // Every minute for 100 minutes
+        }
+
+        (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = wstethOracle.observe(largeArray);
+
+        assertEq(tickCumulatives.length, 100, "Should handle large arrays");
+        assertEq(liquidityCumulatives.length, 100, "Should handle large arrays");
+    }
+
+    function testIncreaseObservationCardinalityNext() public {
+        // Should not revert
+        wstethOracle.increaseObservationCardinalityNext(16);
+        wstethOracle.increaseObservationCardinalityNext(1);
+        wstethOracle.increaseObservationCardinalityNext(type(uint16).max);
+
+        // Values shouldn't change since it's a no-op
+        (,,, uint16 obsCard, uint16 obsCardNext,,) = wstethOracle.slot0();
+        assertEq(obsCard, 65535, "observationCardinality unchanged");
+        assertEq(obsCardNext, 65535, "observationCardinalityNext unchanged");
+    }
+
+    function testPriceConsistencyAcrossTime() public {
+        // Record initial values
+        (, int24 initialTick,,,,,) = wstethOracle.slot0();
+
+        // Fast forward time
+        vm.warp(block.timestamp + 1000);
+
+        // Values should be the same (since we use current Redstone price from same round)
+        (, int24 laterTick,,,,,) = wstethOracle.slot0();
+        assertEq(laterTick, initialTick, "Tick should be consistent across time (same Redstone round)");
     }
 
     function testPriceComparisonWithV4Pool() public {
@@ -79,5 +276,105 @@ contract RedstoneToV3OracleTest is Test {
         uint256 denom = (uint256(1) << 192) / 1e18; // Q192 / 1e18
 
         return FullMath.mulDiv(uint256(sqrtPX96), uint256(sqrtPX96), denom);
+    }
+
+    // Additional test to verify the ordering assumption
+    function testObservationsTimestampOrdering() public {
+        uint32 prevTimestamp;
+
+        // Test that timestamps increase with index
+        for (uint256 i = 0; i < 10; i++) {
+            (uint32 timestamp,,,) = wstethOracle.observations(i);
+
+            if (i > 0) {
+                assertGt(timestamp, prevTimestamp, "Timestamps should increase with index");
+            }
+
+            // Verify the exact formula
+            uint32 expectedTimestamp = uint32(block.timestamp - 65534 + i);
+            assertEq(timestamp, expectedTimestamp, "Timestamp should match formula");
+
+            prevTimestamp = timestamp;
+        }
+    }
+
+    // Test multiple oracles to ensure they work with different price feeds
+    function testMultipleOracles() public {
+        // Test ETH oracle
+        (, int24 ethTick,,,,,) = ethOracle.slot0();
+        assertLt(ethTick, 0, "ETH/USD tick should be negative, unless ETH crashed below 1 dollar");
+
+        // Test TON oracle
+        (, int24 wstethTick,,,,,) = wstethOracle.slot0();
+        // TON price varies, so just check it doesn't revert and returns a valid tick
+        assertLt(wstethTick, 0, "wstETH per ETH tick should be negative, unless wstETH depegged and is worth <1 ETH");
+
+        console.log("ETH tick: ", ethTick);
+        console.log("wstETH tick: ", wstethTick);
+    }
+
+    // Test that different oracles have independent observations
+    function testIndependentObservations() public {
+        // Get observations from different oracles
+        (uint32 wstethTs0, int56 wstethCumulative0,,) = wstethOracle.observations(0);
+        (uint32 ethTs0, int56 ethCumulative0,,) = ethOracle.observations(0);
+
+        // Timestamps should be the same (based on block.timestamp)
+        assertEq(wstethTs0, ethTs0, "Timestamps should be the same across oracles");
+
+        // But cumulatives should be different (different ticks)
+        if (wstethCumulative0 != 0 || ethCumulative0 != 0) {
+            // Only assert if at least one is non-zero to avoid false negatives
+            assertTrue(wstethCumulative0 != ethCumulative0, "Cumulatives should be different for different price feeds");
+        }
+    }
+
+    // Test edge cases with observe function
+    function testObserveEdgeCases() public {
+        // Test with single element array
+        uint32[] memory singleElement = new uint32[](1);
+        singleElement[0] = 0;
+
+        (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = wstethOracle.observe(singleElement);
+
+        assertEq(tickCumulatives.length, 1, "Should return array of length 1");
+        assertEq(liquidityCumulatives.length, 1, "Should return array of length 1");
+        assertEq(liquidityCumulatives[0], 0, "Liquidity cumulative should be 0");
+    }
+
+    // Test that the oracle handles the invertTokenOrder correctly
+    function testTokenOrderInversion() public {
+        // wstethOracle has invertTokenOrder = true
+        (, int24 wstethTick,,,,,) = wstethOracle.slot0();
+
+        // Create another oracle without inversion to compare
+        RedstoneToV3Oracle wstethOracleNoInvert = new RedstoneToV3Oracle(
+            redstoneAdapter,
+            wstethEthPriceFeedId,
+            0,
+            false, // no inversion
+            8
+        );
+
+        (, int24 noInvertTick,,,,,) = wstethOracleNoInvert.slot0();
+
+        // The ticks should be negatives of each other
+        assertEq(wstethTick, -noInvertTick, "Inverted tick should be negative of non-inverted tick");
+    }
+
+    // Test behavior with different decimal configurations
+    function testDecimalDifferences() public {
+        // Test that oracles with different decimal differences work correctly
+        RedstoneToV3Oracle testOracle = new RedstoneToV3Oracle(
+            redstoneAdapter,
+            ethUsdPriceFeedId,
+            -6, // Different decimal difference
+            false,
+            8
+        );
+
+        // Should not revert
+        (, int24 tick,,,,,) = testOracle.slot0();
+        assertTrue(tick > TickMath.MIN_TICK && tick < TickMath.MAX_TICK, "Tick should be within valid range");
     }
 }

--- a/test/RedstoneToV3Oracle.t.sol
+++ b/test/RedstoneToV3Oracle.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+
+import "../src/RedstoneToV3Oracle.sol";
+import "@redstone-finance/core/IRedstoneAdapter.sol";
+import {TickMath} from "v3-core/libraries/TickMath.sol";
+import {FullMath} from "v3-core/libraries/FullMath.sol";
+import {IStateView} from "v4-periphery/src/interfaces/IStateView.sol";
+import {PoolId} from "v4-core-for-periphery/src/types/PoolId.sol";
+
+contract RedstoneToV3OracleTest is Test {
+    RedstoneToV3Oracle ethOracle;
+    RedstoneToV3Oracle tonOracle;
+    RedstoneToV3Oracle wstethOracle;
+
+    bytes32 ethUsdPriceFeedId = bytes32("ETH");
+    bytes32 tonUsdPriceFeedId = bytes32("TON");
+    bytes32 wstethEthPriceFeedId = bytes32("wstETH/ETH");
+
+    IRedstoneAdapter redstoneAdapter = IRedstoneAdapter(
+        0xFB1267A29C0aa19daae4a483ea895862A69e4AA5 // RedstoneAdapter on unichain
+    );
+
+    // https://app.uniswap.org/explore/pools/unichain/0xd10d359f50ba8d1e0b6c30974a65bf06895fba4bf2b692b2c75d987d3b6b863d
+    PoolId wstETHPoolId = PoolId.wrap(0xd10d359f50ba8d1e0b6c30974a65bf06895fba4bf2b692b2c75d987d3b6b863d);
+    // From: https://docs.uniswap.org/contracts/v4/deployments#unichain-130
+    IStateView constant stateView = IStateView(0x86e8631A016F9068C3f085fAF484Ee3F5fDee8f2);
+
+    // And also - this contract is upgradeable - under what circumstances might it get upgraded? Our contracts are non-upgradeable so we won't be able to handle any changes in function signature
+
+    function setUp() public {
+        uint256 forkId = vm.createFork(vm.rpcUrl("unichain"));
+        vm.selectFork(forkId);
+        wstethOracle = new RedstoneToV3Oracle(
+           redstoneAdapter,
+           wstethEthPriceFeedId,
+           0,    // both wstETH and ETH have 18 decimals, so difference is 0
+           true, // need to invertTokenOrder - ETH is token0 and wstETH is token1 on Uniswap, so the tick is wstETH per ETH; the redstone price is ETH per wstETH
+           8     // redstoneDecimals
+       );
+    }
+
+    function testSlot0ReturnsValidPrice() public {
+        // Test that slot0 does not revert
+        (, int24 tick,,,,,) = wstethOracle.slot0();
+        console.log("wstETH Oracle tick: ", tick);
+    }
+
+    function testPriceComparisonWithV4Pool() public {
+        // Get tick from our oracle
+        (, int24 oracleTick,,,,,) = wstethOracle.slot0();
+
+        // Get tick from Uniswap V4 pool using StateView singleton
+        (, int24 poolTick,,) = stateView.getSlot0(wstETHPoolId);
+
+        console.log("Oracle tick: ", oracleTick);
+        console.log("V4 Pool tick: ", poolTick);
+
+
+        // Convert ticks to comparable prices
+        uint256 oraclePrice = convertRawWstethWeiPerEthWeiTickToPrice(oracleTick);
+        uint256 poolPrice = convertRawWstethWeiPerEthWeiTickToPrice(poolTick);
+
+        console.log("wstETH/ETH * 10^18 from Oracle: ", oraclePrice);
+        console.log("wstETH/ETH * 10^18 from Pool: ", poolPrice);
+
+        uint256 priceDiff = oraclePrice > poolPrice ? oraclePrice - poolPrice : poolPrice - oraclePrice;
+
+        // Check if difference is within 1% (priceDiff / poolPrice < 0.01)
+        // priceDiff / poolPrice < 0.01 <=> priceDiff * 100 < poolPrice
+        assertLt(priceDiff * 100, poolPrice, "Oracle price should be within 1% of V4 pool price");
+    }
+
+    function convertRawWstethWeiPerEthWeiTickToPrice(int24 tick) internal pure returns (uint256) {
+        uint160 sqrtPX96 = TickMath.getSqrtRatioAtTick(tick);
+
+        // Put the scale in the denominator to avoid a*b*1e18 overflow.
+        uint256 denom = (uint256(1) << 192) / 1e18; // Q192 / 1e18
+
+        return FullMath.mulDiv(uint256(sqrtPX96), uint256(sqrtPX96), denom);
+    }
+}


### PR DESCRIPTION
This oracle takes a Redstone adapter contract, and a price feed idea, and queries for prices that it then transforms into Uni-v3 compatible values, exposing them in the typical Uni v3 interfaces (slot0, observations, etc).

It's working - I'm getting prices from the oracle that are within 1% of [the biggest (hookless) v4 pool](https://app.uniswap.org/explore/pools/unichain/0xd10d359f50ba8d1e0b6c30974a65bf06895fba4bf2b692b2c75d987d3b6b863d) on Unichain:

```bash
[PASS] testPriceComparisonWithV4Pool() (gas: 50548)
Logs:
  Oracle tick:  -1890
  V4 Pool tick:  -1883
  wstETH/ETH * 10^18 from Oracle:  827794328792712404
  wstETH/ETH * 10^18 from Pool:  828373958688652048
```

0.827794328792712404 wstETH per ETH <=> 1.20802953731 ETH per wstETH
0.828373958688652048 wstETH per ETH <=> 1.20718425478 ETH per wstETH

Edit: and confirmed the values update throughout the day - now (2 hrs later) getting:

```bash
[PASS] testPriceComparisonWithV4Pool() (gas: 50583)
Logs:
  Oracle tick:  -1891
  V4 Pool tick:  -1882
  wstETH/ETH * 10^18 from Oracle:  827711557636948709
  wstETH/ETH * 10^18 from Pool:  828456796084520913
```